### PR TITLE
Don't rely on location of gcc

### DIFF
--- a/unix-sockets.asd
+++ b/unix-sockets.asd
@@ -22,7 +22,7 @@
   t)
 
 (defmethod perform ((o compile-op) (c lib-source-file))
-  (uiop:run-program (list "/usr/bin/gcc" "-shared" "-o" (namestring (car (output-files o c)))
+  (uiop:run-program (list "/usr/bin/env" "gcc" "-shared" "-o" (namestring (car (output-files o c)))
                           "-Werror"
                           "-fPIC"
                           (namestring


### PR DESCRIPTION
Certain Linux distributions like nix and guix doesn't store gcc at this location. Using env is a more portable solution.