### PR TITLE
Added stream-element-type for internal-stream

### DIFF
--- a/ffi.lisp
+++ b/ffi.lisp
@@ -26,6 +26,20 @@
 
 (cffi:defcstruct sockaddr-un)
 
+(cffi:defstruct cmsghdr
+  (cmsg_len :int)
+  (cmsg_level :int)
+  (cmsg_type :int))
+
+(cffi:defcstruct msghdr
+  (msg_name :pointer)
+  (msg_namelen :int)
+  (msg_iov :pointer)
+  (msg_iovlen :int)
+  (msg_control (:pointer (:struct cmsghdr)))
+  (msg_controllen :int)
+  (msg_flags :int))
+
 (cffi:defcfun "socket" :int
   (domain :int)
   (type :int)
@@ -63,6 +77,14 @@
   (buf (:pointer :unsigned-char))
   (count :unsigned-int)
   (flags :int))
+
+(cffi:defcfun ("recvmsg" %recvmsg) :int
+  (fd :int)
+  (msghdr (:pointer (:struct msghdr)))
+  (buf (:pointer :unsigned-char))
+  (count :unsigned-int)
+  (flags :int))
+
 
 (cffi:defcfun ("shutdown" %shutdown) :int
   (fd :int)

--- a/ffi.lisp
+++ b/ffi.lisp
@@ -26,7 +26,7 @@
 
 (cffi:defcstruct sockaddr-un)
 
-(cffi:defstruct cmsghdr
+(cffi:defcstruct cmsghdr
   (cmsg_len :int)
   (cmsg_level :int)
   (cmsg_type :int))

--- a/ffi.lisp
+++ b/ffi.lisp
@@ -81,8 +81,6 @@
 (cffi:defcfun ("recvmsg" %recvmsg) :int
   (fd :int)
   (msghdr (:pointer (:struct msghdr)))
-  (buf (:pointer :unsigned-char))
-  (count :unsigned-int)
   (flags :int))
 
 
@@ -103,6 +101,9 @@
   (fd :int))
 
 (cffi:defcfun "unix_socket_sockaddr_size" :int)
+
+(cffi:defcfun ("cmsg_firsthdr" %cmsg-firsthdr) (:pointer (:struct cmsghdr))
+  (msghdr (:pointer (:struct msghdr))))
 
 (defun errno ()
   #-lispworks

--- a/package.lisp
+++ b/package.lisp
@@ -8,4 +8,5 @@
            #:unix-socket-error
            #:unix-socket-stream
            #:accept-unix-socket
-           #:with-unix-socket))
+           #:with-unix-socket
+	   #:fd))

--- a/streams.lisp
+++ b/streams.lisp
@@ -64,7 +64,7 @@
   ((sock :initarg :sock :accessor sock)
    (ancillary-fd :initarg :ancillary-fd :accessor ancillary-fd)))
 
-(defmethod stream-element-type ((stream internal-stream))
+(defmethod stream-element-type ((stream ancillary-stream))
   'integer)
 
 (defmethod stream-write-byte ((stream ancillary-stream)

--- a/streams.lisp
+++ b/streams.lisp
@@ -5,6 +5,8 @@
   ((sock :initarg :sock
          :accessor sock)))
 
+(defmethod stream-element-type ((stream internal-stream))
+  'integer)
 
 (defmethod stream-write-byte ((stream internal-stream)
                               byte)

--- a/streams.lisp
+++ b/streams.lisp
@@ -48,3 +48,71 @@
             (t
              (log:trace "throwing error ~a" (errno))
              (throw-errno)))))))))
+
+
+;; ┌─┐┌┐┌┌─┐┬┬  ┬  ┌─┐┬─┐┬ ┬
+;; ├─┤││││  ││  │  ├─┤├┬┘└┬┘
+;; ┴ ┴┘└┘└─┘┴┴─┘┴─┘┴ ┴┴└─ ┴
+;; Same as internal-stream, but when reading - provides the possibility to
+;; read the ancillary data from the socket.
+;; TODO: Since i am lazy - this is implemented only to support the cmsg_type SCM_RIGHTS
+;; Which would enable passing file descriptors between processes.
+;; TODO: Ideally this should iterate through CMSG_NXTHDR and read all the ancillary data
+
+(defclass ancillary-stream (fundamental-binary-input-stream
+                           fundamental-binary-output-stream)
+  ((sock :initarg :sock :accessor sock)
+   (ancillary-fd :initarg :ancillary-fd :accessor ancillary-fd)))
+
+(defmethod stream-element-type ((stream internal-stream))
+  'integer)
+
+(defmethod stream-write-byte ((stream ancillary-stream)
+                              byte)
+  (handler-bind ((error (lambda (e)
+                          (log:info "Errr while writing byte: ~a" e))))
+   (let ((buf (buf (sock stream))))
+     (setf (cffi:mem-ref buf :unsigned-char  0)
+           byte)
+     (pcheck (%write (fd (sock stream)) (char-array-to-pointer buf) 1)))))
+
+(defmethod close ((stream ancillary-stream) &key abort)
+  (declare (ignore abort))
+  (shutdown-unix-socket (sock stream)))
+
+(defmethod stream-read-byte ((stream ancillary-stream))
+  (handler-bind ((error (lambda (e)
+                          (log:info "Error while reading byte: ~a" e))))
+   (let ((buf (buf (sock stream)))
+         (fd (fd (sock stream)))
+	 (msghdr (cffi:foreign-alloc 'msghdr))
+	 (cmsghdr (cffi:foreign-alloc 'cmsghdr)))
+     (setf (cffi:slot-value msghdr 'msg_iov) buf)
+     (setf (cffi:slot-value msghdr 'msg_control) cmsghdr)
+     (setf (cffi:slot-value msghdr 'msg_controllen) (cffi:foreign-sizeof 'cmsghdr))
+     (cond
+       ((< fd 0)
+        (log:trace "Sending eof because fd < 0")
+        :eof)
+       (t
+        (let ((num-bytes (%recvmsg fd msghdr 0))
+	      (cmsg (%cmsg-firsthdr msghdr)))
+	  (when (eq (cffi:slot-value cmsg 'cmsg_type) +scm_rights+)
+	    (let ((fd (cffi:mem-ref (cffi:slot-value cmsg 'cmsg_data) :int)))
+	      (setf (ancillary-fd stream) fd)))
+
+          (cond
+            ((eql num-bytes 0)
+             (log:trace "standard eof")
+             :eof)
+            ((> num-bytes 0)
+             (cffi:mem-ref buf :unsigned-char 0))
+            ((= (errno) +econnreset+)
+             ;; AFAICT, this is just like an EOF, at least for the purpose
+             ;; of the stream.
+             ;; https://stackoverflow.com/questions/2974021/what-does-econnreset-mean-in-the-context-of-an-af-local-socket
+             (log:trace "Sending :eof")
+             :eof)
+            (t
+             (log:trace "throwing error ~a" (errno))
+             (throw-errno)))))))))

--- a/unix-sockets.lisp
+++ b/unix-sockets.lisp
@@ -11,6 +11,9 @@
 #+windows
 (error "Only Mac and Linux supported for the moment. Maybe FreeBSD, not sure")
 
+;; NOTE: Other options - 'ancillary-stream
+(defvar *stream-class* 'internal-stream)
+
 (defvar *use-internal-stream-p*
   #+lispworks nil
   #-lispworks t
@@ -121,7 +124,7 @@ testability.")
   (cond
     (*use-internal-stream-p*
      (flexi-streams:make-flexi-stream
-      (make-instance 'internal-stream :sock sock)))
+      (make-instance *stream-class* :sock sock)))
     (t
      #+lispworks
      (make-instance 'comm:socket-stream :socket (fd sock)

--- a/unix_sockets.c
+++ b/unix_sockets.c
@@ -41,3 +41,7 @@ struct sockaddr_un* unix_socket_make_sockaddr(char* path) {
 int unix_socket_sockaddr_size() {
         return sizeof(struct sockaddr_un);
 }
+
+struct cmsghdr cmsg_firsthdr(struct msghdr* msg) {
+  return *CMSG_FIRSTHDR(msg);
+}


### PR DESCRIPTION
Added stream-element-type method for the internal-stream.

Enables the usage of write-sequence on SBCL.